### PR TITLE
getting job logs directly (#153)

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -506,6 +506,13 @@ kubectl get po # get the pod name
 kubectl logs pi-**** # get the pi numbers
 kubectl delete job pi
 ```
+OR 
+
+```bash
+kubectl get jobs -w # wait till 'SUCCESSFUL' is 1 (will take some time, perl image might be big)
+kubectl logs job/pi
+kubectl delete job pi
+```
 
 </p>
 </details>

--- a/f.services.md
+++ b/f.services.md
@@ -181,7 +181,7 @@ kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Network
 kubectl create deployment nginx --image=nginx --replicas=2
 kubectl expose deployment nginx --port=80
 
-kubectl describe svc nginx # see the 'run=nginx' selector for the pods
+kubectl describe svc nginx # see the 'app=nginx' selector for the pods
 # or
 kubectl get svc nginx -o yaml
 
@@ -196,7 +196,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      run: nginx # selector for the pods
+      app: nginx # selector for the pods
   ingress: # allow ingress traffic
   - from:
     - podSelector: # from pods


### PR DESCRIPTION
* Update c.pod_design.md

* Update c.pod_design.md

added alternative way to get logs for a job directly by using job/<jobName> instead of getting pod first

* create deployment label is app=nginx instead of run=nginx 

When using Kubectl create deployment, the system automatically adds label: app=<deploymentName>
On the other hand, when using Kubectl run , the system adds label run=<podName>
Correcting the example since it is creating a deployment.